### PR TITLE
removed mqtt from goto and added token faq

### DIFF
--- a/valetudobot/faq/goto.txt
+++ b/valetudobot/faq/goto.txt
@@ -1,4 +1,4 @@
-keywords: goto, gotolocation, map, ha, mqtt, rest
+keywords: goto, gotolocation, map, rest
 
 title: goto location
 short-title: go-to-location

--- a/valetudobot/faq/token.txt
+++ b/valetudobot/faq/token.txt
@@ -1,0 +1,17 @@
+keywords:
+
+title: API token used for local integrations
+short-title: api-token
+
+text:
+To access the vacuum robot with third party software purely locally you need the API token.
+
+NOTE:
+Do keep in mind that the local miio interface has a singular constantly incrementing message ID counter. Having multiple pieces of software interact with that interface will cause them to fight over who has the latest ID which will result in command delays or timeouts. 
+Make sure to check the Valetudo API first for anything you need, or ask in the channel maybe there already is an easier solution available.
+
+1) If you are rooted and have valetudo installed, this is easy. The token is printed to the Valetudo log on startup. Filter with "LocalSecret"
+2) If you are rooted but don't have valetudo, the token can be extracted by connecting to the device via SSH and reading the file:
+- Roborock - printf $(cat /mnt/data/miio/device.token) | xxd -p
+- Dreame - printf $(cat /data/config/miio/device.token) | xxd -p
+3) If you're not rooted or the above does not work, all the other methods are documented here: https://python-miio.readthedocs.io/en/latest/discovery.html#obtaining-tokens


### PR DESCRIPTION
removing mqtt from goto as it's true it gives an mqtt command but it's not the main subject

token faq is added without token so that it is not accessible as requested by Soren, at the same didn't want to lose the write-up now that it's done. I hope this does not break the bot!